### PR TITLE
Add Python 3 support, prepare for adoption, add parse limit and new settings view

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,38 @@ Analyses gcode for slicer settings comments and adds additional metadata of such
 Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wiki/Plugin:-Plugin-Manager)
 or manually using this URL:
 
-    https://github.com/tjjfvi/OctoPrint-SlicerSettingsParser/archive/master.zip
+    https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser/archive/master.zip
 
-You will most likely want to install another plugin to use the metadata. Such plugins of mine are:
- - [OctoPrint-SlicerSettingsTab](https://github.com/tjjfvi/OctoPrint-SlicerSettingsTab)
+<!-- You will most likely want to install another plugin to use the metadata. Such plugins of mine are:
+ - [OctoPrint-SlicerSettingsTab](https://github.com/tjjfvi/OctoPrint-SlicerSettingsTab) -->
  
-### Cura
-
-Cura doesn't natively support injecting the slicer settings into the gcode, so you must add [this](https://gist.github.com/tjjfvi/75210b2ed20ed194d6eab48bf70c4f12) to your start/end gcode.
 
 ## Configuration
 
+### Cura
+
+Cura doesn't natively support injecting the slicer settings into the gcode, so you must add [this](https://gist.github.com/tjjfvi/75210b2ed20ed194d6eab48bf70c4f12) to your start/end gcode. Preferably add it to the start gcode, so that you can configure this plugin to stop parsing when it sees the first extrusion command.
+
 ### Python regexes (Advanced)
+**Cura**
+If you use the start/end gcode provided above, use this regex:
+```regex
+^;\s*(?P<key>\w+[\w\s]*) : (?P<val>.*)
+```
+
+**Slic3r**
+
+```regex
+^; (?P<key>[^,]*?) = (?P<val>.*)
+```
+
+**Simplify3D**
+
+```regex
+^;   (?P<key>.*?),(?P<val>.*)
+```
+
+**Other**
 
 This plugin uses python regexes to parse the gcode.
 Syntax can be easily found on the web.
@@ -28,4 +48,4 @@ There should be two named capturing groups, `key` and `val`.
 Multiple regexes should be listed on seperate lines, ordered by precedence.
 Any chars are allowed in the groups; `\n` will be replaced by newlines.
 
-See the [wiki](https://github.com/tjjfvi/OctoPrint-SlicerSettingsParser/wiki/Python-regexes) for examples.
+If you can not figure it out yourself, open an issue and I can take a look.

--- a/README.md
+++ b/README.md
@@ -23,20 +23,21 @@ Cura doesn't natively support injecting the slicer settings into the gcode, so y
 
 ### Python regexes (Advanced)
 **Cura**
+
 If you use the start/end gcode provided above, use this regex:
-```regex
+```
 ^;\s*(?P<key>\w+[\w\s]*) : (?P<val>.*)
 ```
 
 **Slic3r**
 
-```regex
+```
 ^; (?P<key>[^,]*?) = (?P<val>.*)
 ```
 
 **Simplify3D**
 
-```regex
+```
 ^;   (?P<key>.*?),(?P<val>.*)
 ```
 

--- a/extras/SlicerSettingsParser.md
+++ b/extras/SlicerSettingsParser.md
@@ -4,15 +4,17 @@ layout: plugin
 id: SlicerSettingsParser
 title: OctoPrint-SlicerSettingsParser
 description: Plugin to analyse gcode for slicer settings comments and add additional metadata of such settings. Useless sans additional plugins to use th
-author: T6
+authors:
+- Larsjuhw
+- T6
 license: AGPLv3
 
 # TODO
 date: today's date in format YYYY-MM-DD, e.g. 2015-04-21
 
-homepage: https://github.com/tjjfvi/OctoPrint-SlicerSettingsParser
-source: https://github.com/tjjfvi/OctoPrint-SlicerSettingsParser
-archive: https://github.com/tjjfvi/OctoPrint-SlicerSettingsParser/archive/master.zip
+homepage: https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser
+source: https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser
+archive: https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser/archive/master.zip
 
 # TODO
 # Set this to true if your plugin uses the dependency_links setup parameter to include

--- a/octoprint_SlicerSettingsParser/static/js/SlicerSettingsParser.js
+++ b/octoprint_SlicerSettingsParser/static/js/SlicerSettingsParser.js
@@ -2,29 +2,35 @@ $(() => {
 	function SlicerSettingsParserViewModel([ settingsViewModel ]){
 		let self = this;
 
-		self.startupComplete = ko.observable(false);
+		self.settingsViewModel = settingsViewModel;
 
+		self.analyzing_files = ko.observable(false);
+		self.done_analysis = ko.observable(false);
+		
 		self.analyzeAll = () => {
 			console.log("SlicerSettingsParser analyze_all");
+			self.analyzing_files(true);
+			self.done_analysis(false);
+			// $('#analyze_files_info').css('display', '');
 			$.ajax({
-			    url: "api/plugin/SlicerSettingsParser",
+			    url: API_BASEURL + "plugin/SlicerSettingsParser",
 			    type: "POST",
 				data:  JSON.stringify({ command: "analyze_all" }),
-				contentType: "application/json",
+				contentType: "application/json; charset=UTF-8",
 			})
+			.then((data) => {
+				self.analyzing_files(false);
+				self.done_analysis(true);
+			});
 		};
-
-		self.joinedRegexes = ko.computed({
-			read: () => self.startupComplete() && self.settings.regexes().join("\n"),
-			write: rs => self.startupComplete() && self.settings.regexes(rs.split("\n")),
-		});
-
-		self.onStartupComplete = () => {
-			console.log("hi!");
+		
+		self.onBeforeBinding = () => {
 			self.settings = settingsViewModel.settings.plugins.SlicerSettingsParser;
-			self.startupComplete(true);
-			// console.log(self.settings.events(), self.events());
-		}
+			self.joinedRegexes = ko.computed({
+				read: () => self.settings.regexes().join("\n"),
+				write: rs => self.settings.regexes(rs.split("\n")),
+			});
+		};
 	}
 
     OCTOPRINT_VIEWMODELS.push({

--- a/octoprint_SlicerSettingsParser/templates/README.txt
+++ b/octoprint_SlicerSettingsParser/templates/README.txt
@@ -1,1 +1,0 @@
-Put your plugin's Jinja2 templates here.

--- a/octoprint_SlicerSettingsParser/templates/SlicerSettingsParser_settings.jinja2
+++ b/octoprint_SlicerSettingsParser/templates/SlicerSettingsParser_settings.jinja2
@@ -1,27 +1,55 @@
+<h3>{{ _('SlicerSettingsParser Settings') }}</h3>
 <form class="form-horizontal">
-    <div class="control-group">
-        <button class="btn" id="SlicerSettingsParser_analyze" data-bind="click: analyzeAll">{{ _('Analyze all files') }}</button>
-    </div>
-    <div>
-        <div>
-            <small>
-                <a href="#" class="muted" onclick="$(this).children().toggleClass('fa-caret-right fa-caret-down').parent().parent().parent().next().slideToggle('fast')">
-                    <i class="fa fa-caret-down"></i> {{ _('Advanced') }}
-                </a>
-            </small>
-        </div>
-        <div class="show" style="display: block;">
-            <div class="control-group">
-                <label class="control-label">{{ _('Python regexes') }}</label>
-                <div class="controls">
-                    <textarea
-                        type="text"
-                        class="input-block-level"
-                        data-bind="value: joinedRegexes"
-                        style='font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace'
-                    ></textarea>
-                </div>
+    <div class="show" style="display: block;">
+        <span>For regex examples, see <a
+                href="https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser#configuration">GitHub</a>.</span>
+        <div class="control-group">
+            <label class="control-label">Python regexes</label>
+            <div class="controls">
+                <textarea type="text" id="testy" class="input-block-level" data-bind="value: joinedRegexes"
+                    style='font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace'></textarea>
             </div>
         </div>
+    </div>
+    <form class="form-horizontal" onsubmit="return false;">
+        <div class="control-group">
+            <label class="control-label"><strong>Gcode lines scan limit</strong></label>
+            <div class="controls">
+                <label class="radio">
+                    <input type="radio" data-bind="checked: settings.limit" name="scan-cutoff" value="none">
+                    No limit
+                </label>
+
+                <label class="radio">
+                    <input type="radio" data-bind="checked: settings.limit" name="scan-cutoff" value="extrusion" data>
+                    Scan until first extrusion
+                </label>
+
+                <label class="radio">
+                    <input type="radio" data-bind="checked: settings.limit" name="scan-cutoff" value="lines">
+                    Scan this number of lines:
+                </label>
+
+                <input type="number" data-bind="enable: settings.limit() == 'lines', value: settings.maxlines"
+                    class="form-control input-mini">
+            </div>
+        </div>
+    </form>
+    <div class="control-group">
+        <button class="btn btn-primary" id="SlicerSettingsParser_analyze"
+            data-bind="click: analyzeAll, enable:!analyzing_files()">
+            <i class="fa fa-spinner fa-spin" data-bind="visible: analyzing_files" style="display: none;"></i>
+            Analyze all files
+        </button>
+    </div>
+    <div class="alert alert-info" data-bind="visible: analyzing_files">
+        <strong>Analyzing all files...</strong><br>
+        This can take a while depending on how much data you have. For reference, a Raspberry Pi 4B
+        should be able to handle about 4 MB/s.
+    </div>
+    <div class="alert alert-success" id="analysis_success" data-bind="visible: done_analysis">
+        <button type="button" class="close" data-bind="click: function(data){done_analysis(false)}"
+            aria-hidden="true">&times;</button>
+        <strong>Done!</strong> You may not see other plugins use the new data before reloading the page.
     </div>
 </form>

--- a/setup.py
+++ b/setup.py
@@ -14,20 +14,20 @@ plugin_package = "octoprint_SlicerSettingsParser"
 plugin_name = "OctoPrint-SlicerSettingsParser"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "2.0.1"
+plugin_version = "3.0.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module
 plugin_description = """Plugin to analyse gcode for slicer settings comments and add additional metadata of such settings. Useless sans additional plugins to use the metadata."""
 
 # The plugin's author. Can be overwritten within OctoPrint's internal data via __plugin_author__ in the plugin module
-plugin_author = "T6"
+plugin_author = "Lars Wolter"
 
 # The plugin's author's mail address.
-plugin_author_email = "t6@t6.fyi"
+plugin_author_email = "larswolter@me.com"
 
 # The plugin's homepage URL. Can be overwritten within OctoPrint's internal data via __plugin_url__ in the plugin module
-plugin_url = "https://github.com/tjjfvi/OctoPrint-SlicerSettingsParser"
+plugin_url = "https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser"
 
 # The plugin's license. Can be overwritten within OctoPrint's internal data via __plugin_license__ in the plugin module
 plugin_license = "AGPLv3"
@@ -59,7 +59,7 @@ plugin_ignored_packages = []
 # Example:
 #     plugin_requires = ["someDependency==dev"]
 #     additional_setup_parameters = {"dependency_links": ["https://github.com/someUser/someRepo/archive/master.zip#egg=someDependency-dev"]}
-additional_setup_parameters = {}
+additional_setup_parameters = {"python_requires": ">=3,<4"}
 
 ########################################################################################################################
 


### PR DESCRIPTION
Change maintainer for plugin adoption.
Drop support for Python 2 and add Python 3 support.
Change settings panel.
Add option to limit the number of lines parsed.