### PR TITLE
Reverse parsing option

### DIFF
--- a/octoprint_SlicerSettingsParser/__init__.py
+++ b/octoprint_SlicerSettingsParser/__init__.py
@@ -75,7 +75,7 @@ class SlicerSettingsParserPlugin(
 		regexes = [re.compile(x) for x in self._settings.get(["regexes"])]
 
 		limit = self._settings.get(['limit'])
-		max_lines = self._settings.get(['maxlines'])
+		max_lines = int(self._settings.get(['maxlines']))
 
 		search_backwards = self._settings.get(["search_backwards"])
 		method = FileReadBackwards if search_backwards else open

--- a/octoprint_SlicerSettingsParser/templates/SlicerSettingsParser_settings.jinja2
+++ b/octoprint_SlicerSettingsParser/templates/SlicerSettingsParser_settings.jinja2
@@ -32,6 +32,11 @@
 
                 <input type="number" data-bind="enable: settings.limit() == 'lines', value: settings.maxlines"
                     class="form-control input-mini">
+
+                <label class="checkbox">
+                    <input type="checkbox" data-bind="checked: settings.search_backwards" class="form-control input-mini">
+                    Parse the file from back to front
+                </label>
             </div>
         </div>
     </form>

--- a/octoprint_SlicerSettingsParser/templates/SlicerSettingsParser_settings.jinja2
+++ b/octoprint_SlicerSettingsParser/templates/SlicerSettingsParser_settings.jinja2
@@ -4,7 +4,7 @@
         <span>For regex examples, see <a
                 href="https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser#configuration">GitHub</a>.</span>
         <div class="control-group">
-            <label class="control-label">Python regexes</label>
+            <label class="control-label"><strong>Python regexes</strong></label>
             <div class="controls">
                 <textarea type="text" id="testy" class="input-block-level" data-bind="value: joinedRegexes"
                     style='font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace'></textarea>
@@ -32,7 +32,13 @@
 
                 <input type="number" data-bind="enable: settings.limit() == 'lines', value: settings.maxlines"
                     class="form-control input-mini">
-
+            </div>
+        </div>
+    </form>
+    <form class="form-horizontal" onsubmit="return false;">
+        <div class="control-group">
+            <label class="control-label"><strong>File search method</strong></label>
+            <div class="controls">
                 <label class="checkbox">
                     <input type="checkbox" data-bind="checked: settings.search_backwards" class="form-control input-mini">
                     Parse the file from back to front

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = []
+plugin_requires = ["file_read_backwards>=3.0.0"]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
Adds the option to reverse parse the file as discussed in #3. Especially usefull for e.g. prusaslicer generated files that have their usefull info at the end instead of at the front.