### PR TITLE
Use compiled regular expression

### DIFF
--- a/octoprint_SlicerSettingsParser/__init__.py
+++ b/octoprint_SlicerSettingsParser/__init__.py
@@ -87,7 +87,7 @@ class SlicerSettingsParserPlugin(
 				if limit == 'extrusion' and octoprint.util.comm.gcode_command_for_cmd(line) == 'G1':
 					break
 				for regex in regexes:
-					match = re.search(regex, line)
+					match = regex.search(line)
 					if not match:
 						continue
 


### PR DESCRIPTION
This improves performance by removing the recompilation of the regular expression when searching each line.