### PR TITLE
Parse only GCODE files

### DIFF
--- a/octoprint_SlicerSettingsParser/__init__.py
+++ b/octoprint_SlicerSettingsParser/__init__.py
@@ -49,7 +49,7 @@ class SlicerSettingsParserPlugin(
 			self._analyze_all()
 
 	def on_event(self, event, payload):
-		if event != "Upload" or payload["target"] != "local" or ospath.splitext(payload["name"]).lower() != "gcode":
+		if event != "Upload" or payload["target"] != "local" or ospath.splitext(payload["name"])[-1].lower() != "gcode":
 			return
 
 		self._analyze_file(payload["path"])

--- a/octoprint_SlicerSettingsParser/__init__.py
+++ b/octoprint_SlicerSettingsParser/__init__.py
@@ -49,7 +49,7 @@ class SlicerSettingsParserPlugin(
 			self._analyze_all()
 
 	def on_event(self, event, payload):
-		if event != "Upload" or payload["target"] != "local" or ospath.splitext(payload["name"])[-1].lower() != "gcode":
+		if event != "Upload" or payload["target"] != "local" or ospath.splitext(payload["name"])[-1].lower() not in ["gcode","gco","g"]:
 			return
 
 		self._analyze_file(payload["path"])

--- a/octoprint_SlicerSettingsParser/__init__.py
+++ b/octoprint_SlicerSettingsParser/__init__.py
@@ -3,6 +3,7 @@ import octoprint.plugin
 import octoprint.filemanager
 import octoprint.util.comm
 import re
+from os import path as ospath
 
 from file_read_backwards import FileReadBackwards
 
@@ -48,7 +49,7 @@ class SlicerSettingsParserPlugin(
 			self._analyze_all()
 
 	def on_event(self, event, payload):
-		if event != "Upload" or payload["target"] != "local":
+		if event != "Upload" or payload["target"] != "local" or ospath.splitext(payload["name"]).lower() != "gcode":
 			return
 
 		self._analyze_file(payload["path"])


### PR DESCRIPTION
Since I have the 'upload anything' plugin installed and I was testing functionality for my own WebDAV plugin, my log was flooded by errors since SlicerSettingsParser was trying to parse STL files I was uploading. This PR is a simple fix to check if the file extension is 'gcode', 'gco' or 'g', as allowed to upload to Octoprint by default.